### PR TITLE
Repaired path to rocketchat.service

### DIFF
--- a/installation/manual-installation/debian/README.md
+++ b/installation/manual-installation/debian/README.md
@@ -92,7 +92,7 @@ WantedBy=multi-user.target
 EOF
 ```
 
-Open the Rocket.Chat service file just created (`/usr/lib/systemd/system/rocketchat.service`) using sudo and your favourite text editor, and change the ROOT_URL environmental variable to reflect the URL you want to use for accessing the server (optionally change MONGO_URL, MONGO_OPLOG_URL and PORT):
+Open the Rocket.Chat service file just created (`/lib/systemd/system/rocketchat.service`) using sudo and your favourite text editor, and change the ROOT_URL environmental variable to reflect the URL you want to use for accessing the server (optionally change MONGO_URL, MONGO_OPLOG_URL and PORT):
 
 ```bash
 MONGO_URL=mongodb://localhost:27017/rocketchat?replicaSet=rs01


### PR DESCRIPTION
The mention of the path to the created rocketchat.service file was wrong (has to be "/lib/systemd" instead of "/usr/lib/systemd") and it has been fixed.